### PR TITLE
Update some Github links and paths

### DIFF
--- a/web-doc/docs/misc/doc-guide.md
+++ b/web-doc/docs/misc/doc-guide.md
@@ -2,9 +2,9 @@
 
 This static documentation website is created by [MkDocs] and is using a theme from [bootswatch].
 
-It uses "github pages" and this site is hosted by Github. The documentation source files are written in Markdown format. 
+It uses "github pages" and this site is hosted by Github. The documentation source files are written in Markdown format.
 
-With MkDocs tool, the generated site files (html files) are automatically pushed into a specific branch `gh-pages` of the git repository. 
+With MkDocs tool, the generated site files (html files) are automatically pushed into a specific branch `gh-pages` of the git repository.
 
 [MkDocs]: https://www.mkdocs.org
 [bootswatch]: https://mkdocs.github.io/mkdocs-bootswatch/
@@ -25,18 +25,18 @@ With MkDocs tool, the generated site files (html files) are automatically pushed
 pip install mkdocs-bootswatch
 ```
 
-Please refer to [bootswatch] for more information. 
+Please refer to [bootswatch] for more information.
 
 ### 3. Install a markdown editor
 
-You can simply edit the markdown (.md) files by any text editor, but it's better to user a professional markdown editor. 
+You can simply edit the markdown (.md) files by any text editor, but it's better to user a professional markdown editor.
 
 * [typora]. It supports all of the platforms (Windows/MacOS/Linux). Please configure typora to `strict` Markdown mode. That ensures you get the same output effects on both **typora** and **mkdocs**.
 
 [typora]: https://typora.io/
 
 
-* [vscode]. It's also a good editor and has abundant functions and extensions. You can install extensions of Markdown, Preview and Spell checker. 
+* [vscode]. It's also a good editor and has abundant functions and extensions. You can install extensions of Markdown, Preview and Spell checker.
 
 [vscode]: https://code.visualstudio.com/
 
@@ -45,20 +45,20 @@ You can simply edit the markdown (.md) files by any text editor, but it's better
 * pdf2svg: This tool can convert a pdf lossless picture to svg format. For Mac OS, it can be easily installed by [Homebrew], simply by `brew install pdf2svg`.
 * Alternative choice is [Inkscape] which is a free drawing tool and can help you draw and convert vector graphics.
 
-[Homebrew]: https://brew.sh/ 
+[Homebrew]: https://brew.sh/
 [Inkscape]: https://inkscape.org/
 
 ## Website Structure
 
-First, you need to git clone the oc-snap repository and go to `web-doc` directory. Make sure you are working on a branch other than master.
+First, you need to git clone the oc-accel repository and go to `web-doc` directory. Make sure you are working on a branch other than master.
 
 ``` bash
-git clone git@github.ibm.com:OC-Enablement/oc-snap.git
+git clone git@github.com:OpenCAPI/oc-accel.git
 git checkout <A branch other than master>
-cd oc-snap/web-doc
+cd oc-accel/web-doc
 ```
 
-The `docs` folder is where to put the markdown files, and the `mkdocs.yml` lists the website structure and global definitons. For example, this site has a structure like: 
+The `docs` folder is where to put the markdown files, and the `mkdocs.yml` lists the website structure and global definitons. For example, this site has a structure like:
 
 ```
 nav:
@@ -83,7 +83,7 @@ nav:
     - 'SNAP Registers': 'deep-dive/registers.md'
     - 'SNAP Logic Design': 'deep-dive/snap_core.md'
     - 'New Board Support': 'deep-dive/board-package.md'
-  - Misc: 
+  - Misc:
     - 'Document Guide': 'misc/doc-guide.md'
 ```
 
@@ -121,14 +121,14 @@ You can insert jpg, png, svg files. You can also simply copy paste pictures from
 
 ### Tools to draw diagrams
 
-You can take any drawing tools to create diagrams. You can save them as PNG format, but the better way is to save to SVG format. 
+You can take any drawing tools to create diagrams. You can save them as PNG format, but the better way is to save to SVG format.
 
 
 For the diagrams from Microsoft PowerPoint, you can select the region of a diagram in PPT, `Ctrl-C` to copy it, and `Ctrl-V` to paste it in Typora directly. In this case, the diagram is saved as an PNG file.
 
 But there is a better way to get the smallest file size and best quality:
 
-- In PowerPoint, select the region of diagram, right-click mouse -> "Save as Picture ..." and save it as "PDF" format. 
+- In PowerPoint, select the region of diagram, right-click mouse -> "Save as Picture ..." and save it as "PDF" format.
 - Open the PDF file with [Inkscape]. (Right-click the file -> "Open with ...", choose Inkscape in the poped up list). Unclick "Embed images" and then "OK".
 - In Inkscape, save it as SVG file.
 - Insert the SVG file into Typora.
@@ -145,22 +145,22 @@ In my experiment, the PNG file is 188KB. But with the above flow to save it as S
 Please assign the code language so it can be correctly rendered. For example ```` C` for C language.
 
 ``` C
-// A function to implement bubble sort 
-void bubbleSort(int arr[], int n) 
-{ 
-   int i, j; 
-   for (i = 0; i < n-1; i++)       
-  
-       // Last i elements are already in place    
-       for (j = 0; j < n-i-1; j++)  
-           if (arr[j] > arr[j+1]) 
-              swap(&arr[j], &arr[j+1]); 
-} 
+// A function to implement bubble sort
+void bubbleSort(int arr[], int n)
+{
+   int i, j;
+   for (i = 0; i < n-1; i++)
+
+       // Last i elements are already in place
+       for (j = 0; j < n-i-1; j++)
+           if (arr[j] > arr[j+1])
+              swap(&arr[j], &arr[j+1]);
+}
 ```
 
 
 ### Admonitions
-You can use `!!! Note` or `!!! Warning` or `!!! Danger` to start a paragraph of admonitions. Then use 4 spaces to start the admonition text. 
+You can use `!!! Note` or `!!! Warning` or `!!! Danger` to start a paragraph of admonitions. Then use 4 spaces to start the admonition text.
 
 For example
 
@@ -178,16 +178,16 @@ It will be shown as:
 
 ## Deploy to Github Pages
 
-When most of the edition work is done, and it's time to commit your documents to oc-snap github. 
+When most of the edition work is done, and it's time to commit your documents to oc-snap github.
 
 First, you should commit and push your changes of source files (in `web-doc`) to git repository. Create pull request, ask someone to review the documents, merge them into master branch after getting approvements.
 
 Then you can simply publish website with just one step:
 
 ``` bash
-cd <PATH>/oc-snap/web-doc
+cd <PATH>/oc-accel/web-doc
 mkdocs gh-deploy
 ```
 
-The entire website will be pushed to `gh-pages` branch of oc-snap repository. The documentation website will be available at <https://pages.github.ibm.com/oc-enablement/oc-snap>!
+The entire website will be pushed to `gh-pages` branch of oc-snap repository. The documentation website will be available at <https://opencapi.github.io/oc-accel/>!
 

--- a/web-doc/docs/repository.md
+++ b/web-doc/docs/repository.md
@@ -6,7 +6,7 @@ This page introduces the components and files in OC-Accel. For a step-by-step gu
 
 # Repository Structure
 
-The diagram below shows the entire diretory structure of OC-Accel GIT repository. It links to another repository [OpenCAPI3.0_Client_RefDesign] or `oc-bip` which contains the card specific packages and modules to support OpenCAPI protocol. 
+The diagram below shows the entire diretory structure of OC-Accel GIT repository. It links to another repository [OpenCAPI3.0_Client_RefDesign] or `oc-bip` which contains the card specific packages and modules to support OpenCAPI protocol.
 
 ![oc-accel-oc-bip](pictures/oc-accel-oc-bip.svg)
 [ OpenCAPI3.0_Client_RefDesign]: https://github.com/OpenCAPI/OpenCAPI3.0_Client_RefDesign
@@ -35,14 +35,14 @@ Then it is the User Application `actions` directory.
 
 ![oc-bip](pictures/oc-bip.svg)
 
-Any card vendor can add their card package support in `oc-bip`. The concept is similar to **DSA** (Device Support Archive) or **BSP** (Board Support Package). 
+Any card vendor can add their card package support in `oc-bip`. The concept is similar to **DSA** (Device Support Archive) or **BSP** (Board Support Package).
 
 * **Board_support_packages**: Card vendor need to create a separate folder for a new device. It includes:
-    1. Constraint files (xdc) to describe the Card pins, flash interface, configurations and so on. 
-    2. Tcl files to create necessary Vivado IPs. 
-    3. *Enprypted* Verilog files to use Xilinx high speed serdes IOs. 
-    4. Verilog files for parameters and FPGA top. 
-* **config_subsystem**: Shared common logic for OpenCAPI Config. 
+    1. Constraint files (xdc) to describe the Card pins, flash interface, configurations and so on.
+    2. Tcl files to create necessary Vivado IPs.
+    3. *Enprypted* Verilog files to use Xilinx high speed serdes IOs.
+    4. Verilog files for parameters and FPGA top.
+* **config_subsystem**: Shared common logic for OpenCAPI Config.
 * **scripts**: to pack the entire `oc-bip` to a Vivado IP (oc_bsp_wrap.xci).
 * **sim**: Top Verilog file for simulation.
 * **Tlx**: OpenCAPI Device transaction layer reference design.
@@ -65,7 +65,7 @@ In accelerator development, software and hardware co-simulation is a very import
 
 ## Top hierarchy in Simulation Step
 
-* **top.sv** is in `oc-bip/sim` directory. 
+* **top.sv** is in `oc-bip/sim` directory.
 * **oc_cfg** is OpenCAPI Configuration subsystem.
 * **oc_function** is the DUT (Design under Test) in this step.
 * **oc_snap_core** is in `hardware/hdl`
@@ -76,7 +76,7 @@ In accelerator development, software and hardware co-simulation is a very import
 
 
 [ Co-Simulation ]: ../user-guide/6-co-simulation/index.html
-[ OCSE ]: https://github.ibm.com/lancet/ocse
+[ OCSE ]: https://github.com/OpenCAPI/ocse
 
 ## Files used in Implementation Step
 
@@ -89,10 +89,10 @@ After co-simulation passed, it's time to do the **Synthesis** and **Implementati
 ## Top hierarchy in Implementation Step
 
 
-To generate a FPGA bitstream (binary image), the top design file is `oc_fpga_top.v`. 
+To generate a FPGA bitstream (binary image), the top design file is `oc_fpga_top.v`.
 
 * **oc_fpga_top** is located in `hardware/oc-bip/board_support_packeages/<CARD>/Verilog/framework_top`
-* **oc_bsp_wrap** includes TLx, Dlx, PHY, Flash subsystem and Card information (VPD). A script `create_oc_bsp.tcl` will assemble these components to a Vivado IP. 
+* **oc_bsp_wrap** includes TLx, Dlx, PHY, Flash subsystem and Card information (VPD). A script `create_oc_bsp.tcl` will assemble these components to a Vivado IP.
 * **oc_cfg** is OpenCAPI Configuration subsystem.
 * **oc_function** is what we have just simulated and proved that the functions can work correctly.
 * **oc_snap_core** is in `hardware/hdl`
@@ -108,7 +108,7 @@ To generate a FPGA bitstream (binary image), the top design file is `oc_fpga_top
 
 When FPGA bit image is generated, use the tool `oc-flash-script` in [oc-utils] (TODO: update link) to download it from Power9 host server to the FPGA flash. After reboot, the bit image takes effect and you can ask application to call FPGA acceleration, with the help of `libosnap` and `libocxl`.
 
-[libocxl] need to be installed. Please follow the README file on its homepage. 
+[libocxl] need to be installed. Please follow the README file on its homepage.
 
 Application software and libosnap need to be compiled on Power9 host server also. For more information, please refer to [User-guide: deploy].
 

--- a/web-doc/docs/user-guide/1-prepare-env.md
+++ b/web-doc/docs/user-guide/1-prepare-env.md
@@ -4,7 +4,7 @@ This page will introduce the basic environmental requests, tools, and general co
 
 ## Basic Tools
 
-Firstly, you need to have an x86 machine for development with [Vivado Tool] and the license. 
+Firstly, you need to have an x86 machine for development with [Vivado Tool] and the license.
 
 ```
 export XILINX_VIVADO=<...path...>/Xilinx/Vivado/<VERSION>
@@ -20,7 +20,7 @@ export PATH=$PATH:${XILINX_VIVADO}/bin
 There is a file `setup_tools.ksh` in the root directory for reference. But for the beginning, only Vivado is required.
 
 Make sure you have `gcc`, `make`, `sed`, `awk`, `xterm` and `python` installed.
-`setup_tools.ksh` 
+`setup_tools.ksh`
 
 You may install other simulators to accelerate the speed of simulation. For example, [Cadence xcelium]. See in [co-simulation] for more information.
 
@@ -37,16 +37,16 @@ You may install other simulators to accelerate the speed of simulation. For exam
 TODO: Link to update
 
 ```
-git clone git@github.ibm.com:OC-Enablement/oc-snap.git
-cd oc-snap
+git clone git@github.com:OpenCAPI/oc-accel.git
+cd oc-accel
 git submodule init
 git submodule update
 
 cd ..
-git clone git@github.ibm.com:lancet/ocse.git
+git clone git@github.com:OpenCAPI/ocse.git
 ```
 
-It's better to have `ocse` stay in the same directory parallel to `oc-snap`. That is the default path of `$OCSE_ROOT`. Or you need to assign `$OCSE_ROOT` explicitly in `snap_env.sh`.
+It's better to have `ocse` stay in the same directory parallel to `oc-accel`. That is the default path of `$OCSE_ROOT`. Or you need to assign `$OCSE_ROOT` explicitly in `snap_env.sh`.
 
 # Basic terms
 ## Option1: All-in-one python script
@@ -55,11 +55,11 @@ OC-Accel developed a "all-in-one" Python script to control the workflow. It's co
 
 
 ```
-cd oc-snap
+cd oc-accel
 ./ocaccel_workflow.py
 ```
 
-This script will 
+This script will
 
 * Check environmental variables
 * make snap_config
@@ -79,7 +79,7 @@ It helps you to do all kinds of operations in one command line.
 If you have used SNAP for CAPI1.0 and CAPI2.0, you can continue to use these "traditional" make steps. Just typing "make" doesn't work. An explicit target is needed. You can find them in `Makefile` file.
 
 ```
-cd oc-snap
+cd oc-accel
 make help
 ```
 
@@ -115,26 +115,26 @@ do only exist on an x86 platform
 
 !!!Note
     After `make model`,  you can continue to run `make image` to generate bitstreams.
-    
+
 
 In fact, `make model` also creates a Vivado project `framework.xpr` in `hardware/viv_project`. Then it exports the simulation files and compiles them to a simulation model.
 
 
 ### For Image build
 
-* `make snap_config` If it has already been executed, no need to run it again. 
+* `make snap_config` If it has already been executed, no need to run it again.
 * `make hw_project`
 * `make image`
 
 !!!Note
-    **Use Vivado GUI**: 
+    **Use Vivado GUI**:
 
-    After `make hw_project`, you can open project `framework.xpr` in `hardware/viv_project`, and do following **"run Synthesis"**, **"run Implementation"** and **"generate Bitstream"** in Vivado GUI. 
+    After `make hw_project`, you can open project `framework.xpr` in `hardware/viv_project`, and do following **"run Synthesis"**, **"run Implementation"** and **"generate Bitstream"** in Vivado GUI.
 
 
 ## Output files
 
-* The log files during these steps are placed in `hardware/logs`. 
+* The log files during these steps are placed in `hardware/logs`.
 
 * Simulation output files are placed in `hardware/sim/<SIMULATOR>/latest`.
 

--- a/web-doc/docs/user-guide/2-run-helloworld.md
+++ b/web-doc/docs/user-guide/2-run-helloworld.md
@@ -16,17 +16,17 @@ Select HLS HelloWorld in "Action Type".
 
 ![select-helloworld](./pictures/2-select-helloworld.png)
 
-There are some other choices listed in the menu. Please input `OCSE_ROOT` path. Select `xsim` (the default simulator). 
+There are some other choices listed in the menu. Please input `OCSE_ROOT` path. Select `xsim` (the default simulator).
 
-To select a TRUE/FALSE feature, press "Y" or "N". After everything done, move cursor to "Exit". 
+To select a TRUE/FALSE feature, press "Y" or "N". After everything done, move cursor to "Exit".
 
 !!!Note
     This Kconfig menu is editable. If you want to add new features or enrich your own menu, please edit `scripts/Kconfig` file.
 
 
-Then it starts to execute many steps to build a simulation model. It needs several minutes. While waiting for it, open another terminal tab and try to get familiar with some environmental variables. Open `snap_env.sh` and check the very basic ones: 
+Then it starts to execute many steps to build a simulation model. It needs several minutes. While waiting for it, open another terminal tab and try to get familiar with some environmental variables. Open `snap_env.sh` and check the very basic ones:
 ``` bash
-export ACTION_ROOT=<path_of_oc-snap>/actions/hls_helloworld
+export ACTION_ROOT=<path_of_oc-accel>/actions/hls_helloworld
 export TIMING_LABLIMIT="-200"
 export OCSE_ROOT=<path_to_ocse>/ocse
 ```
@@ -59,11 +59,11 @@ Runnig ... check ./snap_workflow.make_model.log for details of full progress
 Then a Xterm window will popped up. (If it doesn't, check if you have installed it by typing `xterm` in your terminal.)
 ![xterm-window](./pictures/2-xterm-window.png)
 
-This Xterm window is where you run your application (software part). You can run anything as many times as you want in the xterm window, just like running in the terminal of a real server with FPGA card plugged. 
+This Xterm window is where you run your application (software part). You can run anything as many times as you want in the xterm window, just like running in the terminal of a real server with FPGA card plugged.
 
 !!!Warning
     If you want to save the content running in this xterm window, please use `script` before running any commands. When you exit xterm window, everything is saved to a file -- "typescript" is its default name.
-    
+
 ```
 $ script
 Script started, file is typescript
@@ -73,7 +73,7 @@ exit
 Script done, file is typescript
 ```
 
-Now let's run application **snap_helloworld**. It is located in `$ACTION_ROOT/sw`, where $ACTION_ROOT is `<path_of_oc-snap>/actions/hls_helloworld`. In the above window, it prints the help messages because it requires two arguments: an input text file and an output text file. 
+Now let's run application **snap_helloworld**. It is located in `$ACTION_ROOT/sw`, where $ACTION_ROOT is `<path_of_oc-accel>/actions/hls_helloworld`. In the above window, it prints the help messages because it requires two arguments: an input text file and an output text file.
 
 We have prepared a script in `$ACTION_ROOT/tests/hw_test.sh` and you can run it directly.
 
@@ -81,9 +81,9 @@ This example is asking FPGA to read the input file from host memory, converting 
 
 ![hw-test](./pictures/2-hw-test.png)
 
-Now you have finished the software/hardware co-simulation. 
+Now you have finished the software/hardware co-simulation.
 
-Type 'exit' in xterm window. 
+Type 'exit' in xterm window.
 
 All the output logs, waveforms are in `hardware/sim/<simulator>/latest`.
 ```
@@ -100,9 +100,9 @@ xsim top.wdb -gui &
 ```
 ![waveform](./pictures/2-waveform.png)
 
-On the project scope (hierarchy) panel, the user logic is `action_w`. 
+On the project scope (hierarchy) panel, the user logic is `action_w`.
 
-## Make FPGA bit image 
+## Make FPGA bit image
 
 In above steps, you actually have finished steps of:
 
@@ -143,13 +143,13 @@ After termination it can be restarted later.
     start route_design      with directive: Explore             18:04:55 Sat Sep 14 2019
     start opt_routed_design with directive: Explore             18:39:01 Sat Sep 14 2019
     generating reports                                          18:57:28 Sat Sep 14 2019
-    Timing (WNS)            -11 ps                                                    
-                            WARNING: TIMING FAILED, but may be OK for lab use                      
+    Timing (WNS)            -11 ps
+                            WARNING: TIMING FAILED, but may be OK for lab use
     generating bitstreams   type: user image                    18:58:28 Sat Sep 14 2019
 ```
 So you can have an estimation of the progress.
 
-After it's completed, you can find the FPGA bit image files in `hardware/build/Images`. The file names have the information of build date/time, action name, card type and timing slack (-11ps here). 
+After it's completed, you can find the FPGA bit image files in `hardware/build/Images`. The file names have the information of build date/time, action name, card type and timing slack (-11ps here).
 
 ```
 $ cd hardware/build/Images

--- a/web-doc/docs/user-guide/3-new-action.md
+++ b/web-doc/docs/user-guide/3-new-action.md
@@ -11,9 +11,9 @@ git submodule init
 git submodule update
 ```
 
-Delete the unnecessary branches, only keep "master", and create your own branches. 
+Delete the unnecessary branches, only keep "master", and create your own branches.
 
-When you want to sync with the original repository, do following steps: 
+When you want to sync with the original repository, do following steps:
 
 ```
 git remote add upstream https://github.com/ORIGINAL_OWNER/ORIGINAL_REPOSITORY.git
@@ -34,10 +34,10 @@ git fetch upstream
 git merge upstream/master
 ```
 
-When you have some fixes and added some new features, create a pull request from your fork to the original repository. It will be reviewed and then the contribution will be merged. 
+When you have some fixes and added some new features, create a pull request from your fork to the original repository. It will be reviewed and then the contribution will be merged.
 
 !!!Note
-    OC-Accel encourages people to create their own actions and the links will be recommended on `README.md`. But to keep the repository relatively small and neat, it will not copy every user action design into its original `actions` folder. 
+    OC-Accel encourages people to create their own actions and the links will be recommended on `README.md`. But to keep the repository relatively small and neat, it will not copy every user action design into its original `actions` folder.
 
     Submit an **issue** or **pull** request to start the discussion.
 
@@ -59,11 +59,11 @@ We have several examples as references. Current action example list is:
 [hls_helloworld]: ../../actions-doc/hls_helloworld/index.html
 [hls_memcopy_1024]: ../../actions-doc/hls_memcopy_1024/index.html
 
-According to the action category, copy the folder of a proper example from `actions` and name it. 
+According to the action category, copy the folder of a proper example from `actions` and name it.
 
 ## Give it a name and type
 
-**Step1:** 
+**Step1:**
 
 ```
 make snap_config
@@ -78,14 +78,14 @@ Select `HLS Action - manually set ...` or `HDL Action - manually set ...` in the
 Edit `snap_env.sh`, point $ACTION_ROOT to the new action.
 
 ``` bash
-export ACTION_ROOT=<...path...>/oc-snap/actions/my_new_action
+export ACTION_ROOT=<...path...>/oc-accel/actions/my_new_action
 export TIMING_LABLIMIT="-200"
 export OCSE_ROOT=<...path...>/ocse
 ```
 
 **Step3:**
 
-Edit `software/tools/snap_actions.h`, add a row of the new action, with the company/person name, action type ID, and a short description. 
+Edit `software/tools/snap_actions.h`, add a row of the new action, with the company/person name, action type ID, and a short description.
 
 ``` C
 static const struct actions_tab snap_actions[] = {
@@ -111,18 +111,18 @@ Do a `grep` search and replace them.
 
 ## Understand the workflow
 
-Modify the example code (sw, hw and tests) to cook a new action. 
+Modify the example code (sw, hw and tests) to cook a new action.
 
-Understanding the workflow can help quickly identifying what's wrong. These steps are organized in 
+Understanding the workflow can help quickly identifying what's wrong. These steps are organized in
 
 * `Makefile`
 * `hardware/Makefile`
 * `software/Makefile`
-* Actions --> 
+* Actions -->
     * `$ACTION_ROOT/hw/Makefile`
     * `$ACTION_ROOT/sw/Makefile`
 
-When adding a new action, before calling the "All-in-one" ocaccel_workflow.py, make sure the make process under $ACTION_ROOT works. 
+When adding a new action, before calling the "All-in-one" ocaccel_workflow.py, make sure the make process under $ACTION_ROOT works.
 ```
 cd $ACTION_ROOT/sw
 make
@@ -138,7 +138,7 @@ Above figure shows the steps to make a simulation model. The Action related step
 * Build Date/Time, Git Version and Card info will be hardcoded into snap_core logic by "**patch_version.sh**"
 
 ## Start simulation
-After clean up compiling errors in action sw and action hw, kick off a co-simulation by 
+After clean up compiling errors in action sw and action hw, kick off a co-simulation by
 
 ```
 ./ocaccel_workflow.py

--- a/web-doc/mkdocs.yml
+++ b/web-doc/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: OC-Accel Doc
-repo_url: https://github.ibm.com/OC-Enablement/oc-snap
+repo_url: https://github.com/OpenCAPI/oc-accel
 repo_name: GitHub
 nav:
   - About:
@@ -27,7 +27,7 @@ nav:
     - 'Registers': 'deep-dive/registers.md'
     - 'Hardware Logic': 'deep-dive/hardware-logic.md'
     - 'New Board Support': 'deep-dive/board-package.md'
-  - Misc: 
+  - Misc:
     - 'Document Guide': 'misc/doc-guide.md'
 theme:
   name: yeti


### PR DESCRIPTION
This updates some internal IBM Github links to public Github.com links.
I also noticed that there is no public `oc-utils` repository in the [OpenCAPI](https://github.com/OpenCAPI) organization yet.