### PR TITLE
MISC -- give ocse a controllable timeout value.

### DIFF
--- a/scripts/ide/ocaccel_workflow.py
+++ b/scripts/ide/ocaccel_workflow.py
@@ -81,7 +81,7 @@ parser.add_option("-s", "--simulator", dest="simulator", default=None,
                   help="Simulator used for simulation. No default value.", metavar="<nosim, xcelium, xsim>")
 parser.add_option("-t", "--testcase", dest="testcase", default="terminal",
                   help="Testcase used for simulation, default: %default", metavar="STRING")
-parser.add_option("--simulator_start_timeout", dest="sim_timeout", type="int", default=60,
+parser.add_option("--simulator_start_timeout", dest="sim_timeout", type="int", default=600,
                   help="How long we will wait for simulator to start (in seconds), default: %default")
 parser.add_option("--make_timeout", dest="make_timeout", type="int", default=2592000,
                   help="How long we will wait for make model or make image to finish (in seconds), default: %default")

--- a/scripts/ide/run_sim.py
+++ b/scripts/ide/run_sim.py
@@ -46,7 +46,7 @@ from ocaccel_utils import msg
 class SimSession:
     def __init__(self, simulator_name = 'xsim', testcase_cmd = 'snap_example', testcase_args = "",\
                  ocse_root = os.path.abspath('../ocse'), ocaccel_root = os.path.abspath('.'),\
-                 sim_timeout = 60, unit_sim = False, sv_seed = '1', unit_test = '', uvm_ver = '', wave = True):
+                 sim_timeout = 600, unit_sim = False, sv_seed = '1', unit_test = '', uvm_ver = '', wave = True):
         # prepare the environment
         self.simulator_name = simulator_name
         self.testcase_cmd = testcase_cmd

--- a/scripts/ide/run_sim.py
+++ b/scripts/ide/run_sim.py
@@ -66,7 +66,7 @@ class SimSession:
         self.simulator = Simulator(simulator_name, self.ocaccel_root, self.sim_timeout, self.unit_sim, self.sv_seed, self.unit_test, self.uvm_ver, self.wave)
         # No OCSE if in unit sim mode
         if self.unit_sim == False:
-            self.ocse = OCSE(ocse_root, self.simulator.simout)
+            self.ocse = OCSE(ocse_root, self.simulator.simout, self.sim_timeout)
         self.testcase = Testcase(testcase_cmd, self.simulator.simout, testcase_args)
 
     def run(self):
@@ -335,10 +335,10 @@ class Simulator:
         msg.header_msg(" Simulator running successfully on socket: %s" % host_shim)
 
 class OCSE:
-    def __init__(self, ocse_root = os.path.abspath('../ocse'), simout = '.'):
+    def __init__(self, ocse_root = os.path.abspath('../ocse'), simout = '.', timeout = 300):
         self.ocse_root = ocse_root
         self.simout = simout
-        self.timeout = 30
+        self.timeout = timeout
         self.ocse_pid = None
         self.setup()
 
@@ -379,7 +379,7 @@ class OCSE:
         ocse_server_dat_line = None
         progress_bar_size = 30
         for i in range(self.timeout):
-            sleep(0.25)
+            sleep(1)
             progress_bar(i, self.timeout, progress_bar_size)
             ocse_server_dat_line = grep_file(self.ocse_log, "listening on")
             if ocse_server_dat_line is not None:


### PR DESCRIPTION
1) --simulator_start_timeout <timeout_value> to control ocse timeout as well.

Signed-off-by: Peng Fei GOU <shgoupf@cn.ibm.com>