### PR TITLE
HBM test pass on AD9H7

### DIFF
--- a/hardware/hdl/core/framework_afu.v
+++ b/hardware/hdl/core/framework_afu.v
@@ -509,6 +509,47 @@ module framework_afu (
   wire [ `AXI_CARD_MEM_ID_WIDTH-1 : 0 ]    act_axi_card_mem0_rid       ;
 
   `ifdef ENABLE_HBM
+    `ifdef AD9H7
+  wire [ `AXI_CARD_MEM_ADDR_WIDTH-1 : 0 ]   hbm_slice_awaddr            ;
+  wire [ 7 : 0 ]                            hbm_slice_awlen             ;
+  wire [ 2 : 0 ]                            hbm_slice_awsize            ;
+  wire [ 1 : 0 ]                            hbm_slice_awburst           ;
+  wire                                      hbm_slice_awlock            ;
+  wire [ 3 : 0 ]                            hbm_slice_awcache           ;
+  wire [ 2 : 0 ]                            hbm_slice_awprot            ;
+  wire [ 3 : 0 ]                            hbm_slice_awregion          ;
+  wire [ 3 : 0 ]                            hbm_slice_awqos             ;
+  wire                                      hbm_slice_awvalid           ;
+  wire                                      hbm_slice_awready           ;
+  wire [255: 0 ]                            hbm_slice_wdata             ;
+  wire [31 : 0 ]                            hbm_slice_wstrb             ;
+  wire                                      hbm_slice_wlast             ;
+  wire                                      hbm_slice_wvalid            ;
+  wire                                      hbm_slice_wready            ;
+  wire [ 1 : 0 ]                            hbm_slice_bresp             ;
+  wire                                      hbm_slice_bvalid            ;
+  wire                                      hbm_slice_bready            ;
+  wire [ `AXI_CARD_MEM_ADDR_WIDTH-1 : 0 ]   hbm_slice_araddr            ;
+  wire [ 7 : 0 ]                            hbm_slice_arlen             ;
+  wire [ 2 : 0 ]                            hbm_slice_arsize            ;
+  wire [ 1 : 0 ]                            hbm_slice_arburst           ;
+  wire                                      hbm_slice_arlock            ;
+  wire [ 3 : 0 ]                            hbm_slice_arcache           ;
+  wire [ 2 : 0 ]                            hbm_slice_arprot            ;
+  wire [ 3 : 0 ]                            hbm_slice_arregion          ;
+  wire [ 3 : 0 ]                            hbm_slice_arqos             ;
+  wire                                      hbm_slice_arvalid           ;
+  wire                                      hbm_slice_arready           ;
+  wire [255: 0 ]                            hbm_slice_rdata             ;
+  wire [ 1 : 0 ]                            hbm_slice_rresp             ;
+  wire                                      hbm_slice_rlast             ;
+  wire                                      hbm_slice_rvalid            ;
+  wire                                      hbm_slice_rready            ;
+  wire [ 5 : 0 ]                            hbm_slice_arid              ;
+  wire [ 5 : 0 ]                            hbm_slice_awid              ;
+  wire [ 5 : 0 ]                            hbm_slice_bid               ;
+  wire [ 5 : 0 ]                            hbm_slice_rid               ;
+    `endif
   wire [ `AXI_CARD_MEM_ADDR_WIDTH-1 : 0 ]   hbm_ctrl_awaddr             ;
   wire [ 7 : 0 ]                            hbm_ctrl_awlen              ;
   wire [ 2 : 0 ]                            hbm_ctrl_awsize             ;
@@ -2031,6 +2072,7 @@ block_RAM block_ram_i1
 `endif
 
 `ifdef ENABLE_HBM
+`ifdef AD9H3
   //
   // Action to HBM controller AXI data width converter
   // HBM controller is 256b AXI3 interface
@@ -2117,6 +2159,178 @@ assign  hbm_ctrl_arid[`AXI_CARD_MEM_ID_WIDTH-1 : 0] = act_axi_card_mem0_arid;
 assign  hbm_ctrl_arid[5 : `AXI_CARD_MEM_ID_WIDTH]   = 'b0;
 assign  act_axi_card_mem0_bid = hbm_ctrl_bid[`AXI_CARD_MEM_ID_WIDTH-1 : 0];
 assign  act_axi_card_mem0_rid = hbm_ctrl_rid[`AXI_CARD_MEM_ID_WIDTH-1 : 0];
+
+`elsif AD9H7
+ axi_hbm_dwidth_converter axi_dwidth_converter_act2hbm (
+      .s_axi_aclk        ( clock_act                   ) ,
+      .s_axi_aresetn     ( hbm_ctrl_reset_n            ) ,
+      .s_axi_awaddr      ( act_axi_card_mem0_awaddr    ) ,
+      .s_axi_awlen       ( act_axi_card_mem0_awlen     ) ,
+      .s_axi_awsize      ( act_axi_card_mem0_awsize    ) ,
+      .s_axi_awburst     ( act_axi_card_mem0_awburst   ) ,
+      .s_axi_awlock      ( act_axi_card_mem0_awlock[0] ) ,
+      .s_axi_awcache     ( act_axi_card_mem0_awcache   ) ,
+      .s_axi_awprot      ( act_axi_card_mem0_awprot    ) ,
+      .s_axi_awregion    ( act_axi_card_mem0_awregion  ) ,
+      .s_axi_awqos       ( act_axi_card_mem0_awqos     ) ,
+      .s_axi_awvalid     ( act_axi_card_mem0_awvalid   ) ,
+      .s_axi_awready     ( act_axi_card_mem0_awready   ) ,
+      .s_axi_wdata       ( act_axi_card_mem0_wdata     ) ,
+      .s_axi_wstrb       ( act_axi_card_mem0_wstrb     ) ,
+      .s_axi_wlast       ( act_axi_card_mem0_wlast     ) ,
+      .s_axi_wvalid      ( act_axi_card_mem0_wvalid    ) ,
+      .s_axi_wready      ( act_axi_card_mem0_wready    ) ,
+      .s_axi_bresp       ( act_axi_card_mem0_bresp     ) ,
+      .s_axi_bvalid      ( act_axi_card_mem0_bvalid    ) ,
+      .s_axi_bready      ( act_axi_card_mem0_bready    ) ,
+      .s_axi_araddr      ( act_axi_card_mem0_araddr    ) ,
+      .s_axi_arlen       ( act_axi_card_mem0_arlen     ) ,
+      .s_axi_arsize      ( act_axi_card_mem0_arsize    ) ,
+      .s_axi_arburst     ( act_axi_card_mem0_arburst   ) ,
+      .s_axi_arlock      ( act_axi_card_mem0_arlock[0] ) ,
+      .s_axi_arcache     ( act_axi_card_mem0_arcache   ) ,
+      .s_axi_arprot      ( act_axi_card_mem0_arprot    ) ,
+      .s_axi_arregion    ( act_axi_card_mem0_arregion  ) ,
+      .s_axi_arqos       ( act_axi_card_mem0_arqos     ) ,
+      .s_axi_arvalid     ( act_axi_card_mem0_arvalid   ) ,
+      .s_axi_arready     ( act_axi_card_mem0_arready   ) ,
+      .s_axi_rdata       ( act_axi_card_mem0_rdata     ) ,
+      .s_axi_rresp       ( act_axi_card_mem0_rresp     ) ,
+      .s_axi_rlast       ( act_axi_card_mem0_rlast     ) ,
+      .s_axi_rvalid      ( act_axi_card_mem0_rvalid    ) ,
+      .s_axi_rready      ( act_axi_card_mem0_rready    ) ,
+
+      .m_axi_awaddr      ( hbm_slice_awaddr            ) ,
+      .m_axi_awlen       ( hbm_slice_awlen             ) ,
+      .m_axi_awsize      ( hbm_slice_awsize            ) ,
+      .m_axi_awburst     ( hbm_slice_awburst           ) ,
+      .m_axi_awlock      ( hbm_slice_awlock            ) ,
+      .m_axi_awcache     ( hbm_slice_awcache           ) ,
+      .m_axi_awprot      ( hbm_slice_awprot            ) ,
+      .m_axi_awregion    ( hbm_slice_awregion          ) ,
+      .m_axi_awqos       ( hbm_slice_awqos             ) ,
+      .m_axi_awvalid     ( hbm_slice_awvalid           ) ,
+      .m_axi_awready     ( hbm_slice_awready           ) ,
+      .m_axi_wdata       ( hbm_slice_wdata             ) ,
+      .m_axi_wstrb       ( hbm_slice_wstrb             ) ,
+      .m_axi_wlast       ( hbm_slice_wlast             ) ,
+      .m_axi_wvalid      ( hbm_slice_wvalid            ) ,
+      .m_axi_wready      ( hbm_slice_wready            ) ,
+      .m_axi_bresp       ( hbm_slice_bresp             ) ,
+      .m_axi_bvalid      ( hbm_slice_bvalid            ) ,
+      .m_axi_bready      ( hbm_slice_bready            ) ,
+      .m_axi_araddr      ( hbm_slice_araddr            ) ,
+      .m_axi_arlen       ( hbm_slice_arlen             ) ,
+      .m_axi_arsize      ( hbm_slice_arsize            ) ,
+      .m_axi_arburst     ( hbm_slice_arburst           ) ,
+      .m_axi_arlock      ( hbm_slice_arlock            ) ,
+      .m_axi_arcache     ( hbm_slice_arcache           ) ,
+      .m_axi_arprot      ( hbm_slice_arprot            ) ,
+      .m_axi_arregion    ( hbm_slice_arregion          ) ,
+      .m_axi_arqos       ( hbm_slice_arqos             ) ,
+      .m_axi_arvalid     ( hbm_slice_arvalid           ) ,
+      .m_axi_arready     ( hbm_slice_arready           ) ,
+      .m_axi_rdata       ( hbm_slice_rdata             ) ,
+      .m_axi_rresp       ( hbm_slice_rresp             ) ,
+      .m_axi_rlast       ( hbm_slice_rlast             ) ,
+      .m_axi_rvalid      ( hbm_slice_rvalid            ) ,
+      .m_axi_rready      ( hbm_slice_rready            )
+) ; 
+
+assign  hbm_slice_awid[`AXI_CARD_MEM_ID_WIDTH-1 : 0] = act_axi_card_mem0_awid;
+assign  hbm_slice_awid[5 : `AXI_CARD_MEM_ID_WIDTH]   = 'b0;
+assign  hbm_slice_arid[`AXI_CARD_MEM_ID_WIDTH-1 : 0] = act_axi_card_mem0_arid;
+assign  hbm_slice_arid[5 : `AXI_CARD_MEM_ID_WIDTH]   = 'b0;
+assign  act_axi_card_mem0_bid = hbm_slice_bid[`AXI_CARD_MEM_ID_WIDTH-1 : 0];
+assign  act_axi_card_mem0_rid = hbm_slice_rid[`AXI_CARD_MEM_ID_WIDTH-1 : 0];
+
+  //
+  // AXI Regitser Slice for SLR Crossing
+  //
+ axi_hbm_register_slice axi_hbm_reg_slice (
+      .aclk              ( clock_act                   ) ,
+      .aresetn           ( hbm_ctrl_reset_n            ) ,
+      .s_axi_awaddr      ( hbm_slice_awaddr            ) ,
+      .s_axi_awlen       ( hbm_slice_awlen             ) ,
+      .s_axi_awsize      ( hbm_slice_awsize            ) ,
+      .s_axi_awburst     ( hbm_slice_awburst           ) ,
+      .s_axi_awid        ( hbm_slice_awid              ) ,
+      .s_axi_awlock      ( hbm_slice_awlock            ) ,
+      .s_axi_awcache     ( hbm_slice_awcache           ) ,
+      .s_axi_awprot      ( hbm_slice_awprot            ) ,
+      .s_axi_awregion    ( hbm_slice_awregion          ) ,
+      .s_axi_awqos       ( hbm_slice_awqos             ) ,
+      .s_axi_awvalid     ( hbm_slice_awvalid           ) ,
+      .s_axi_awready     ( hbm_slice_awready           ) ,
+      .s_axi_wdata       ( hbm_slice_wdata             ) ,
+      .s_axi_wstrb       ( hbm_slice_wstrb             ) ,
+      .s_axi_wlast       ( hbm_slice_wlast             ) ,
+      .s_axi_wvalid      ( hbm_slice_wvalid            ) ,
+      .s_axi_wready      ( hbm_slice_wready            ) ,
+      .s_axi_bresp       ( hbm_slice_bresp             ) ,
+      .s_axi_bvalid      ( hbm_slice_bvalid            ) ,
+      .s_axi_bready      ( hbm_slice_bready            ) ,
+      .s_axi_bid         ( hbm_slice_bid               ) ,
+      .s_axi_araddr      ( hbm_slice_araddr            ) ,
+      .s_axi_arlen       ( hbm_slice_arlen             ) ,
+      .s_axi_arsize      ( hbm_slice_arsize            ) ,
+      .s_axi_arburst     ( hbm_slice_arburst           ) ,
+      .s_axi_arid        ( hbm_slice_arid              ) ,
+      .s_axi_arlock      ( hbm_slice_arlock            ) ,
+      .s_axi_arcache     ( hbm_slice_arcache           ) ,
+      .s_axi_arprot      ( hbm_slice_arprot            ) ,
+      .s_axi_arregion    ( hbm_slice_arregion          ) ,
+      .s_axi_arqos       ( hbm_slice_arqos             ) ,
+      .s_axi_arvalid     ( hbm_slice_arvalid           ) ,
+      .s_axi_arready     ( hbm_slice_arready           ) ,
+      .s_axi_rdata       ( hbm_slice_rdata             ) ,
+      .s_axi_rresp       ( hbm_slice_rresp             ) ,
+      .s_axi_rlast       ( hbm_slice_rlast             ) ,
+      .s_axi_rvalid      ( hbm_slice_rvalid            ) ,
+      .s_axi_rready      ( hbm_slice_rready            ) ,
+      .s_axi_rid         ( hbm_slice_rid               ) ,
+
+      .m_axi_awaddr      ( hbm_ctrl_awaddr             ) ,
+      .m_axi_awlen       ( hbm_ctrl_awlen              ) ,
+      .m_axi_awsize      ( hbm_ctrl_awsize             ) ,
+      .m_axi_awburst     ( hbm_ctrl_awburst            ) ,
+      .m_axi_awid        ( hbm_ctrl_awid               ) ,
+      .m_axi_awlock      ( hbm_ctrl_awlock             ) ,
+      .m_axi_awcache     ( hbm_ctrl_awcache            ) ,
+      .m_axi_awprot      ( hbm_ctrl_awprot             ) ,
+      .m_axi_awregion    ( hbm_ctrl_awregion           ) ,
+      .m_axi_awqos       ( hbm_ctrl_awqos              ) ,
+      .m_axi_awvalid     ( hbm_ctrl_awvalid            ) ,
+      .m_axi_awready     ( hbm_ctrl_awready            ) ,
+      .m_axi_wdata       ( hbm_ctrl_wdata              ) ,
+      .m_axi_wstrb       ( hbm_ctrl_wstrb              ) ,
+      .m_axi_wlast       ( hbm_ctrl_wlast              ) ,
+      .m_axi_wvalid      ( hbm_ctrl_wvalid             ) ,
+      .m_axi_wready      ( hbm_ctrl_wready             ) ,
+      .m_axi_bresp       ( hbm_ctrl_bresp              ) ,
+      .m_axi_bvalid      ( hbm_ctrl_bvalid             ) ,
+      .m_axi_bready      ( hbm_ctrl_bready             ) ,
+      .m_axi_bid         ( hbm_ctrl_bid                ) ,
+      .m_axi_araddr      ( hbm_ctrl_araddr             ) ,
+      .m_axi_arlen       ( hbm_ctrl_arlen              ) ,
+      .m_axi_arsize      ( hbm_ctrl_arsize             ) ,
+      .m_axi_arburst     ( hbm_ctrl_arburst            ) ,
+      .m_axi_arid        ( hbm_ctrl_arid               ) ,
+      .m_axi_arlock      ( hbm_ctrl_arlock             ) ,
+      .m_axi_arcache     ( hbm_ctrl_arcache            ) ,
+      .m_axi_arprot      ( hbm_ctrl_arprot             ) ,
+      .m_axi_arregion    ( hbm_ctrl_arregion           ) ,
+      .m_axi_arqos       ( hbm_ctrl_arqos              ) ,
+      .m_axi_arvalid     ( hbm_ctrl_arvalid            ) ,
+      .m_axi_arready     ( hbm_ctrl_arready            ) ,
+      .m_axi_rdata       ( hbm_ctrl_rdata              ) ,
+      .m_axi_rresp       ( hbm_ctrl_rresp              ) ,
+      .m_axi_rlast       ( hbm_ctrl_rlast              ) ,
+      .m_axi_rvalid      ( hbm_ctrl_rvalid             ) ,
+      .m_axi_rready      ( hbm_ctrl_rready             ) ,
+      .m_axi_rid         ( hbm_ctrl_rid                )
+) ;
+`endif
 
 assign hbm_ctrl_reset_n = hbm_ctrl_apb_complete & ~reset_action_q;
 

--- a/hardware/hdl/oc/brdg_tlx_cmd_converter.v
+++ b/hardware/hdl/oc/brdg_tlx_cmd_converter.v
@@ -149,6 +149,7 @@ module brdg_tlx_cmd_converter (
  wire        fifo_w_datcnv_e_ovfl; 
  wire        fifo_w_datcnv_o_ovfl; 
  wire        fifo_w_cmdcnv_ovfl; 
+ wire        fifo_w_cmdcnv_empty;
  reg         tlx_in_cmd_req;
  reg         tlx_in_cmd_ack;
  reg         tlx_in_cmd_rec;
@@ -273,7 +274,7 @@ module brdg_tlx_cmd_converter (
                                 .dout          (fifo_w_cmdcnv_dout  ),
                                 .wr_data_count (fifo_w_cmdcnv_wrcnt ), 
                                 .overflow      (fifo_w_cmdcnv_ovfl  ),
-                                .empty         ()
+                                .empty         (fifo_w_cmdcnv_empty )
                                 );
 
 //---- FIFO for higher 64B write data ----
@@ -393,10 +394,10 @@ module brdg_tlx_cmd_converter (
    if(~rst_n) 
      cmd_crankshaft_sub <= 1'b0;
    else 
-     cmd_crankshaft_sub <= cmd_crankshaft_main && ~cmd_credit_run_out && ~cmd_data_credit_lt_2;
+     cmd_crankshaft_sub <= fifo_w_cmdcnv_rdrq;
 
- assign fifo_w_cmdcnv_rdrq   =  cmd_crankshaft_main && ~cmd_credit_run_out && ~cmd_data_credit_lt_2;
- assign fifo_w_datcnv_e_rdrq =  cmd_crankshaft_main && ~cmd_credit_run_out && ~cmd_data_credit_lt_2;
+ assign fifo_w_cmdcnv_rdrq   =  cmd_crankshaft_main && ~cmd_credit_run_out && ~cmd_data_credit_lt_2 && ~fifo_w_cmdcnv_empty;
+ assign fifo_w_datcnv_e_rdrq =  fifo_w_cmdcnv_rdrq;
  assign fifo_w_datcnv_o_rdrq =  cmd_crankshaft_sub;
  assign fifo_r_cmdcnv_rdrq   = ~cmd_crankshaft_main && ~cmd_credit_run_out &&  fifo_a_cmdcnv_empty && ~tlx_interrupt_valid_pre;
  assign fifo_a_cmdcnv_rdrq   = ~cmd_crankshaft_main && ~cmd_credit_run_out && ~fifo_a_cmdcnv_empty && ~tlx_interrupt_valid_pre;

--- a/hardware/setup/create_snap_ip.tcl
+++ b/hardware/setup/create_snap_ip.tcl
@@ -994,8 +994,8 @@ if { $create_ddr4_ad9v3 == "TRUE" } {
   open_example_project -in_process -force -dir $ip_dir     [get_ips ddr4sdram] >> $log_file
 }
 
-#HBM controller(AD9H3)
-if { $create_hbm_ad9h3 == "TRUE" } {
+#HBM controller(AD9H3/AD9H7)
+if { ($create_hbm_ad9h3 == "TRUE") || ($create_hbm_ad9h7 == "TRUE") } {
   puts "                        generating axi_hbm_dwidth_converter ......"
   create_ip -name axi_dwidth_converter -vendor xilinx.com -library ip -version 2.1 -module_name axi_hbm_dwidth_converter -dir $ip_dir  >> $log_file
   set_property -dict [list CONFIG.PROTOCOL {AXI4}              \
@@ -1046,6 +1046,25 @@ if { $create_hbm_ad9h3 == "TRUE" } {
   generate_target all                          [get_files $ip_dir/hbm_ctrl/hbm_ctrl.xci]                    >> $log_file
   export_ip_user_files -of_objects             [get_files $ip_dir/hbm_ctrl/hbm_ctrl.xci] -no_script -force  >> $log_file
   export_simulation -of_objects [get_files $ip_dir/hbm_ctrl/hbm_ctrl.xci] -directory $ip_dir/ip_user_files/sim_scripts -force >> $log_file
+}
+
+if { $create_hbm_ad9h7 == "TRUE" } {
+  puts "                        generating axi_hbm_register_slice ......"
+  create_ip -name axi_register_slice -vendor xilinx.com -library ip -version 2.1 -module_name axi_hbm_register_slice -dir $ip_dir  >> $log_file
+  set_property -dict [list CONFIG.ADDR_WIDTH {33}              \
+                           CONFIG.DATA_WIDTH {256}             \
+                           CONFIG.ID_WIDTH {6}                 \
+                           CONFIG.REG_AW {7}                   \
+                           CONFIG.REG_AR {7}                   \
+                           CONFIG.REG_W {1}                    \
+                           CONFIG.REG_R {1}                    \
+                           CONFIG.REG_B {7}                    \
+                           ] [get_ips axi_hbm_register_slice]
+  set_property generate_synth_checkpoint false [get_files $ip_dir/axi_hbm_register_slice/axi_hbm_register_slice.xci] >> $log_file
+  generate_target {instantiation_template}     [get_files $ip_dir/axi_hbm_register_slice/axi_hbm_register_slice.xci] >> $log_file
+  generate_target all                          [get_files $ip_dir/axi_hbm_register_slice/axi_hbm_register_slice.xci] >> $log_file
+  export_ip_user_files -of_objects             [get_files $ip_dir/axi_hbm_register_slice/axi_hbm_register_slice.xci] -no_script -sync -force  >> $log_file
+  export_simulation    -of_objects             [get_files $ip_dir/axi_hbm_register_slice/axi_hbm_register_slice.xci] -directory $ip_dir/ip_user_files/sim_scripts -force >> $log_file
 }
 
 # User IPs


### PR DESCRIPTION
1. add axi register slice for SLR crossing
2. fix oc bridge bug on tlx cmd and data fifo read logic

Signed-off-by: Liu Yang Fan <shliuyf@cn.ibm.com>