### PR TITLE
oc_find_card: Added -t option to tell which accel type (CAPI1,2 or 3) you want to work with

### DIFF
--- a/software/tools/oc_find_card
+++ b/software/tools/oc_find_card
@@ -336,23 +336,7 @@ if  [ $CardOption == 1 ]; then
         	fi
 	fi
 
-	if [ $type -eq 2 ] || [ $type -eq 1 ] || [ $type -eq 0 ]; then # CAPI1/CAPI2 or nothing requested (no -t option)
-		detect_card_name $card  "0x0632" "0x0605" "ADKU3"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x060a" "N250S"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0607" "S121B_v16.1_BPIx16"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0664" "S121B_v16.2_SPIx4"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
+	if [ $type -eq 2 ] || [ $type -eq 0 ]; then # CAPI2 or nothing requested (no -t option)
 		detect_card_name $card  "0x0632" "0x060c" "RCXVUP"
 		if [ $? == 1 ]; then
 			rc=1
@@ -366,10 +350,6 @@ if  [ $CardOption == 1 ]; then
 			rc=1
 		fi
 		detect_card_name $card  "0x0632" "0x0660" "S241"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0608" "AD8K5"
 		if [ $? == 1 ]; then
 			rc=1
 		fi
@@ -389,6 +369,32 @@ if  [ $CardOption == 1 ]; then
 		if [ $? == 1 ]; then
 			rc=1
 		fi
+	fi
+
+	if [ $type -eq 1 ] || [ $type -eq 0 ]; then # CAPI1 or nothing requested (no -t option)
+		detect_card_name $card  "0x0632" "0x0605" "ADKU3"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x060a" "N250S"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0607" "S121B_v16.1_BPIx16"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0664" "S121B_v16.2_SPIx4"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0608" "AD8K5"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+	fi
+
+	if [ $type -eq 0 ]; then # nothing requested specific cases(no -t option)
 		detect_card_name $card  "0x0602" "" "GZIP"
 		if [ $? == 1 ]; then
 			rc=1

--- a/software/tools/oc_find_card
+++ b/software/tools/oc_find_card
@@ -262,7 +262,7 @@ function detect_oc_card_name()
 # Main Start here
 # Parse any options given on the command line
 PROGRAM=$0
-card=""
+CardOption=0
 type=""
 while getopts ":vA:C:Vht:" opt; do
 	case ${opt} in
@@ -275,6 +275,7 @@ while getopts ":vA:C:Vht:" opt; do
 		;;
 	C)
 		card=${OPTARG};
+		CardOption=1
 		;;
 	t)
 		type=${OPTARG}
@@ -301,7 +302,7 @@ done
 shift $((OPTIND-1))
 # now do something with $@
 
-if  ["$card" != ""]; then
+if  [ $CardOption == 1 ]; then
   	rc=0
 	if [[ $card -gt 3 ]]; then
 		echo "Invalid option for -C -$OPTARG" >&2

--- a/software/tools/oc_find_card
+++ b/software/tools/oc_find_card
@@ -29,7 +29,9 @@ normal=$(tput sgr0)
 
 # v2.0 : modified Jan 16th 2018 to have -v option providing extra information
 # v2.1 : modified Feb 26th 2020 adding AD9Hx in CAPI2 and OC modes
-version=2.1
+# v2.2 : modified March 19th 2020 adding -t (accel type) option; this is to prevent reporting 2 cards (1 CAPI2, 1 OpenCAPI) as only 1 card with 2 characteristics (both have $card ID=0)
+
+version=2.2
 accel=UNKNOWN
 VERBOSE=0
 
@@ -263,7 +265,7 @@ function detect_oc_card_name()
 # Parse any options given on the command line
 PROGRAM=$0
 CardOption=0
-type=""
+type=0
 while getopts ":vA:C:Vht:" opt; do
 	case ${opt} in
 	v)
@@ -304,13 +306,20 @@ shift $((OPTIND-1))
 
 if  [ $CardOption == 1 ]; then
   	rc=0
+
 	if [[ $card -gt 3 ]]; then
 		echo "Invalid option for -C -$OPTARG" >&2
 		usage
 		exit 0
 	fi
 
-	if [ $type -eq 3 ]; then
+	if [[ $type -gt 3 ]]; then
+		echo "Invalid option for -t -$OPTARG" >&2
+		usage
+		exit 0
+	fi
+
+	if [ $type -eq 3 ] || [ $type -eq 0 ]; then # OpenCAPI or nothing requested (no -t option)
 		detect_oc_card_name $card  "0x062b" "0x060f" "OC-AD9V3"
     	if [ $? == 1 ]; then
         	rc=1
@@ -323,8 +332,9 @@ if  [ $CardOption == 1 ]; then
         	if [ $? == 1 ]; then
             	rc=1
         	fi
+	fi
 
-	else
+	if [ $type -eq 2 ] || [ $type -eq 1 ] || [ $type -eq 0 ]; then # CAPI1/CAPI2 or nothing requested (no -t option)
 		detect_card_name $card  "0x0632" "0x0605" "ADKU3"
 		if [ $? == 1 ]; then
 			rc=1

--- a/software/tools/oc_find_card
+++ b/software/tools/oc_find_card
@@ -309,74 +309,80 @@ if  [ $CardOption == 1 ]; then
 		usage
 		exit 0
 	fi
-	detect_card_name $card  "0x0632" "0x0605" "ADKU3"
-	if [ $? == 1 ]; then
-		rc=1
+
+	if [ $type -eq 3 ]; then
+		detect_oc_card_name $card  "0x062b" "0x060f" "OC-AD9V3"
+    	if [ $? == 1 ]; then
+        	rc=1
+    	fi
+		detect_oc_card_name $card  "0x062b" "0x0667" "OC-AD9H3"
+		if [ $? == 1 ]; then
+        	rc=1
+		fi
+    	detect_oc_card_name $card  "0x062b" "0x0666" "OC-AD9H7"
+        	if [ $? == 1 ]; then
+            	rc=1
+        	fi
+
+	else
+		detect_card_name $card  "0x0632" "0x0605" "ADKU3"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x060a" "N250S"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0607" "S121B_v16.1_BPIx16"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0664" "S121B_v16.2_SPIx4"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x060c" "RCXVUP"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x060d" "N250SP"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0661" "FX609"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0660" "S241"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0608" "AD8K5"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x04dd" "N250SP"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x060f" "AD9V3"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0667" "AD9H3"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0665" "U200"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0602" "" "GZIP"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
 	fi
-	detect_card_name $card  "0x0632" "0x060a" "N250S"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x0607" "S121B_v16.1_BPIx16"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x0664" "S121B_v16.2_SPIx4"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x060c" "RCXVUP"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x060d" "N250SP"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x0661" "FX609"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x0660" "S241"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x0608" "AD8K5"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x04dd" "N250SP"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x060f" "AD9V3"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x0667" "AD9H3"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0632" "0x0665" "U200"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_card_name $card  "0x0602" "" "GZIP"
-	if [ $? == 1 ]; then
-		rc=1
-	fi
-	detect_oc_card_name $card  "0x062b" "0x060f" "OC-AD9V3"
-    if [ $? == 1 ]; then
-        rc=1
-    fi
-	detect_oc_card_name $card  "0x062b" "0x0667" "OC-AD9H3"
-	 if [ $? == 1 ]; then
-        rc=1
-	fi
-    detect_oc_card_name $card  "0x062b" "0x0666" "OC-AD9H7"
-        if [ $? == 1 ]; then
-            rc=1
-        fi
+
 	exit $rc
 fi
 

--- a/software/tools/oc_find_card
+++ b/software/tools/oc_find_card
@@ -39,6 +39,7 @@ function usage() {
 	echo "    [-v] Prints extra information (to be put as first param)"
 	echo "    [-A] <accelerator> use either ADKU3, N250S, S121B_BPIx16, S121B_SPIx4, AD8K5, RCXVUP, FX609, S241, N250SP, AD9V3, OC-AD9V3, AD9H3, OC-AD9H3, AD9H7, OC-AD9H7, U200 or ALL"
 	echo "    [-C] <0..3> Print accelerator name for this Card"
+	echo "    [-t] <1..3> Specifies the Type of CAPI: CAPI1.0, CAPI2.0 or OPENCAPI (CAPI3.0)"
 	echo "    [-V] provides version"
 	echo "  prints out a list of CAPI Cards found in this System."
 	echo
@@ -261,7 +262,9 @@ function detect_oc_card_name()
 # Main Start here
 # Parse any options given on the command line
 PROGRAM=$0
-while getopts ":vA:C:Vh" opt; do
+card=""
+type=""
+while getopts ":vA:C:Vht:" opt; do
 	case ${opt} in
 	v)
 		VERBOSE=1
@@ -272,81 +275,9 @@ while getopts ":vA:C:Vh" opt; do
 		;;
 	C)
 		card=${OPTARG};
-		rc=0
-		if [[ $card -gt 3 ]]; then
-			echo "Invalid option for -C -$OPTARG" >&2
-			usage
-			exit 0
-		fi
-		detect_card_name $card  "0x0632" "0x0605" "ADKU3"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x060a" "N250S"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0607" "S121B_v16.1_BPIx16"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0664" "S121B_v16.2_SPIx4"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x060c" "RCXVUP"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x060d" "N250SP"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0661" "FX609"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0660" "S241"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0608" "AD8K5"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x04dd" "N250SP"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x060f" "AD9V3"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0667" "AD9H3"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0632" "0x0665" "U200"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_card_name $card  "0x0602" "" "GZIP"
-		if [ $? == 1 ]; then
-			rc=1
-		fi
-		detect_oc_card_name $card  "0x062b" "0x060f" "OC-AD9V3"
-                if [ $? == 1 ]; then
-                        rc=1
-                fi
-		detect_oc_card_name $card  "0x062b" "0x0667" "OC-AD9H3"
-		 if [ $? == 1 ]; then
-		        rc=1
-		fi
-                detect_oc_card_name $card  "0x062b" "0x0666" "OC-AD9H7"
-                 if [ $? == 1 ]; then
-                        rc=1
-                fi
-		exit $rc
+		;;
+	t)
+		type=${OPTARG}
 		;;
 	V)
 		echo "${version}" >&2
@@ -369,6 +300,85 @@ done
 
 shift $((OPTIND-1))
 # now do something with $@
+
+if  ["$card" != ""]; then
+  	rc=0
+	if [[ $card -gt 3 ]]; then
+		echo "Invalid option for -C -$OPTARG" >&2
+		usage
+		exit 0
+	fi
+	detect_card_name $card  "0x0632" "0x0605" "ADKU3"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x060a" "N250S"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x0607" "S121B_v16.1_BPIx16"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x0664" "S121B_v16.2_SPIx4"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x060c" "RCXVUP"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x060d" "N250SP"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x0661" "FX609"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x0660" "S241"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x0608" "AD8K5"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x04dd" "N250SP"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x060f" "AD9V3"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x0667" "AD9H3"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0632" "0x0665" "U200"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_card_name $card  "0x0602" "" "GZIP"
+	if [ $? == 1 ]; then
+		rc=1
+	fi
+	detect_oc_card_name $card  "0x062b" "0x060f" "OC-AD9V3"
+    if [ $? == 1 ]; then
+        rc=1
+    fi
+	detect_oc_card_name $card  "0x062b" "0x0667" "OC-AD9H3"
+	 if [ $? == 1 ]; then
+        rc=1
+	fi
+    detect_oc_card_name $card  "0x062b" "0x0666" "OC-AD9H7"
+        if [ $? == 1 ]; then
+            rc=1
+        fi
+	exit $rc
+fi
+
 RC=0
 
 case ${accel} in

--- a/software/tools/oc_find_card
+++ b/software/tools/oc_find_card
@@ -369,6 +369,14 @@ if  [ $CardOption == 1 ]; then
 		if [ $? == 1 ]; then
 			rc=1
 		fi
+		detect_card_name $card  "0x0632" "0x0666" "AD9H7"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
+		detect_card_name $card  "0x0632" "0x0669" "U50"
+		if [ $? == 1 ]; then
+			rc=1
+		fi
 	fi
 
 	if [ $type -eq 1 ] || [ $type -eq 0 ]; then # CAPI1 or nothing requested (no -t option)
@@ -394,7 +402,7 @@ if  [ $CardOption == 1 ]; then
 		fi
 	fi
 
-	if [ $type -eq 0 ]; then # nothing requested specific cases(no -t option)
+	if [ $type -eq 0 ]; then # nothing requested => specific cases (no -t option)
 		detect_card_name $card  "0x0602" "" "GZIP"
 		if [ $? == 1 ]; then
 			rc=1
@@ -467,11 +475,11 @@ case ${accel} in
 		detect_snap_cards "0x062b" "0x0667" "OC-AD9H3"
 		RC=$?
 		;;
-        # OC-AD9H7 OpenCAPI 3.0 card from Alphadata
-        "OC-AD9H7")
-                detect_snap_cards "0x062b" "0x0666" "OC-AD9H7"
-                RC=$?
-                ;;
+	# OC-AD9H7 OpenCAPI 3.0 card from Alphadata
+    "OC-AD9H7")
+        detect_snap_cards "0x062b" "0x0666" "OC-AD9H7"
+        RC=$?
+        ;;
 	# U200 CAPI 2.0 card from Xilinx
 	"U200")
 		detect_snap_cards "0x0632" "0x0665" "U200"
@@ -487,11 +495,17 @@ case ${accel} in
 		detect_snap_cards "0x0632" "0x0667" "AD9H3"
 		RC=$?
 		;;
-        # AD9H7 CAPI 2.0 card from Alphadata
-        "AD9H7")
-                detect_snap_cards "0x0632" "0x0666" "AD9H7"
-                RC=$?
-                ;;
+    # AD9H7 CAPI 2.0 card from Alphadata
+    "AD9H7")
+        detect_snap_cards "0x0632" "0x0666" "AD9H7"
+        RC=$?
+        ;;
+    # U50 CAPI 2.0 card from Xilinx
+    "U50")
+        detect_snap_cards "0x0632" "0x0669" "U50"
+        RC=$?
+        ;;
+
 	"ALL")
 		# detect all cards and add Number of Cards
 		detect_snap_cards "0x0632" "0x0605" "ADKU3"
@@ -527,10 +541,16 @@ case ${accel} in
 		detect_snap_cards "0x0632" "0x060f" "AD9V3"
 		RC=$((RC + $?))
 
-                detect_snap_cards "0x0632" "0x0667" "AD9H3"
+        detect_snap_cards "0x0632" "0x0667" "AD9H3"
 		RC=$((RC + $?))
 
 		detect_snap_cards "0x0632" "0x0665" "U200"
+		RC=$((RC + $?))
+
+		detect_snap_cards "0x0632" "0x0666" "AD9H7"
+		RC=$((RC + $?))
+
+        detect_snap_cards "0x0632" "0x0669" "U50"
 		RC=$((RC + $?))
 
 		detect_snap_cards "0x062b" "0x060f" "OC-AD9V3"
@@ -539,8 +559,8 @@ case ${accel} in
 		detect_snap_cards "0x062b" "0x0667" "OC-AD9H3"
 		RC=$((RC + $?))
 
-                detect_snap_cards "0x062b" "0x0666" "OC-AD9H7"
-                RC=$((RC + $?))
+        detect_snap_cards "0x062b" "0x0666" "OC-AD9H7"
+        RC=$((RC + $?))
 
 		echo -e "\nTotal $RC cards detected \n"
  		;;

--- a/software/tools/oc_find_card
+++ b/software/tools/oc_find_card
@@ -58,6 +58,8 @@ function usage() {
         echo "        Prints a list of OC-AD9V3 OpenCAPI Cards found"
 	echo "     $PROGRAM -C 0"
 	echo "         Prints the Type of CAPI/OpenCAPI Card 0"
+	echo "     $PROGRAM -C 0 -t 3"
+	echo "         Prints the Type of OpenCAPI-only Card 0"
 	echo "     $PROGRAM -v -A ALL"
 	echo "         Prints Verbose Informations for all CAPI/OpenCAPI Cards"
 	echo "  Exit code will return how many accelerator's are available."


### PR DESCRIPTION
Added -t (accel type) option; 
This is to prevent reporting 2 cards (1 CAPI2, 1 OpenCAPI) as only 1 card with 2 characteristics (both have $card ID=0).
Example: oc_find_card -C0 running on a system with 2 cards, like 1 AD9V3 and 1 OC-AD9V3 was reporting "AD9V3OC-AD9V3", which is not a valid accel type, and was crashing other script (like oc_jenkins.sh) using it.

Also
  - Added U50 CAPI2 card.
  - AD9H7 was missing for -AALL option.