### PR TITLE
100G receiving queue, 9H3/VU35P compatibility, and minor HLS modifications

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hardware/oc-bip"]
 	path = hardware/oc-bip
-	url = https://github.com/OpenCAPI/OpenCAPI3.0_Client_RefDesign.git
+	url = https://github.com/fleon-psi/OpenCAPI3.0_Client_RefDesign.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hardware/oc-bip"]
 	path = hardware/oc-bip
-	url = https://github.com/fleon-psi/OpenCAPI3.0_Client_RefDesign.git
+	url = https://github.com/OpenCAPI/OpenCAPI3.0_Client_RefDesign.git

--- a/ActionTypes.md
+++ b/ActionTypes.md
@@ -18,7 +18,8 @@ IBM | 10.14.30.0E | 10.14.30.0E | HLS Memcopy_512   (512b)
 IBM | 10.14.30.0F | 10.14.30.0F | HLS Decimal Mult  (512b)
 IBM | 10.14.30.10 | 10.14.30.10 | HLS UDP           (512b)
 IBM | 10.14.30.11 | 10.14.FF.FF | Reserved for HLS IBM Actions
-PSI | 52.32.00.01 | 52.32.00.FF | X-ray Detector Data Acquisition and Analysis
+PSI | 52.32.01.00 | 52.32.01.00 | JUNGFRAU X-ray Detector Data Acquisition and Analysis
+PSI | 52.32.01.01 | 52.32.01.FF | X-ray Detector Data Acquisition and Analysis
 Reserved | FF.FF.00.00 | FF.FF.FF.FF | Reserved
 
 ### How to apply for a new Action Type

--- a/actions/scripts/create_run_hls_script.sh
+++ b/actions/scripts/create_run_hls_script.sh
@@ -121,6 +121,7 @@ set_part ${part_number}
 create_clock -period ${clock_period} -name default
 config_interface -m_axi_addr64=true
 #config_rtl -reset all -reset_level low
+config_schedule -enable_dsp_full_reg=true
 
 csynth_design
 #export_design -format ip_catalog -rtl vhdl

--- a/defconfig/OC-AD9H335.hdl_example.defconfig
+++ b/defconfig/OC-AD9H335.hdl_example.defconfig
@@ -1,0 +1,89 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+HDL_EXAMPLE=y
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+# HLS_HELLOWORLD_PYTHON is not set
+# HLS_HBM_MEMCOPY_1024 is not set
+# HLS_IMAGE_FILTER is not set
+# HLS_DECIMAL_MULT is not set
+# HLS_UDP is not set
+# HLS_RX100G is not set
+ACTION_HALF_WIDTH=y
+HALF_WIDTH="TRUE"
+# ENABLE_HLS_SUPPORT is not set
+HLS_SUPPORT="FALSE"
+# DISABLE_SDRAM_AND_BRAM is not set
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+# DISABLE_HBM is not set
+HBM_USED="FALSE"
+# ENABLE_BRAM is not set
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+# ENABLE_ETHERNET is not set
+# DISABLE_ETHERNET is not set
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hdl_single_engine.defconfig
+++ b/defconfig/OC-AD9H335.hdl_single_engine.defconfig
@@ -1,0 +1,86 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+HDL_SINGLE_ENGINE=y
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+# HLS_HELLOWORLD_PYTHON is not set
+# HLS_HBM_MEMCOPY_1024 is not set
+# HLS_IMAGE_FILTER is not set
+# HLS_DECIMAL_MULT is not set
+# HLS_UDP is not set
+# HLS_RX100G is not set
+HALF_WIDTH="FALSE"
+# ENABLE_HLS_SUPPORT is not set
+HLS_SUPPORT="FALSE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+# DISABLE_HBM is not set
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+DISABLE_ETHERNET=y
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hls_decimal_mult.defconfig
+++ b/defconfig/OC-AD9H335.hls_decimal_mult.defconfig
@@ -1,0 +1,87 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+# HLS_HELLOWORLD_PYTHON is not set
+# HLS_HBM_MEMCOPY_1024 is not set
+# HLS_IMAGE_FILTER is not set
+HLS_DECIMAL_MULT=y
+# HLS_UDP is not set
+# HLS_RX100G is not set
+ACTION_HALF_WIDTH=y
+HALF_WIDTH="TRUE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+DISABLE_HBM=y
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+DISABLE_ETHERNET=y
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hls_hbm_memcopy_1024.defconfig
+++ b/defconfig/OC-AD9H335.hls_hbm_memcopy_1024.defconfig
@@ -1,0 +1,90 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+# HLS_HELLOWORLD_PYTHON is not set
+HLS_HBM_MEMCOPY_1024=y
+# HLS_IMAGE_FILTER is not set
+# HLS_DECIMAL_MULT is not set
+# HLS_UDP is not set
+# HLS_RX100G is not set
+HALF_WIDTH="FALSE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+# DISABLE_SDRAM_AND_BRAM is not set
+FORCE_SDRAM_OR_BRAM=y
+SDRAM_USED="FALSE"
+# DISABLE_HBM is not set
+FORCE_HBM=y
+ENABLE_HBM=y
+HBM_USED="TRUE"
+# ENABLE_BRAM is not set
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+DISABLE_ETHERNET=y
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+HBM_AXI_IF_NUM=12
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hls_helloworld_1024.defconfig
+++ b/defconfig/OC-AD9H335.hls_helloworld_1024.defconfig
@@ -1,0 +1,86 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+HLS_HELLOWORLD_1024=y
+# HLS_HELLOWORLD_PYTHON is not set
+# HLS_HBM_MEMCOPY_1024 is not set
+# HLS_IMAGE_FILTER is not set
+# HLS_DECIMAL_MULT is not set
+# HLS_UDP is not set
+# HLS_RX100G is not set
+HALF_WIDTH="FALSE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+DISABLE_HBM=y
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+DISABLE_ETHERNET=y
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hls_helloworld_512.defconfig
+++ b/defconfig/OC-AD9H335.hls_helloworld_512.defconfig
@@ -1,0 +1,87 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+HLS_HELLOWORLD_512=y
+# HLS_HELLOWORLD_1024 is not set
+# HLS_HELLOWORLD_PYTHON is not set
+# HLS_HBM_MEMCOPY_1024 is not set
+# HLS_IMAGE_FILTER is not set
+# HLS_DECIMAL_MULT is not set
+# HLS_UDP is not set
+# HLS_RX100G is not set
+ACTION_HALF_WIDTH=y
+HALF_WIDTH="TRUE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+DISABLE_HBM=y
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+DISABLE_ETHERNET=y
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hls_helloworld_python.defconfig
+++ b/defconfig/OC-AD9H335.hls_helloworld_python.defconfig
@@ -1,0 +1,86 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+HLS_HELLOWORLD_PYTHON=y
+# HLS_HBM_MEMCOPY_1024 is not set
+# HLS_IMAGE_FILTER is not set
+# HLS_DECIMAL_MULT is not set
+# HLS_UDP is not set
+# HLS_RX100G is not set
+HALF_WIDTH="FALSE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+DISABLE_HBM=y
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+DISABLE_ETHERNET=y
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hls_image_filter.defconfig
+++ b/defconfig/OC-AD9H335.hls_image_filter.defconfig
@@ -1,0 +1,87 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+# HLS_HELLOWORLD_PYTHON is not set
+# HLS_HBM_MEMCOPY_1024 is not set
+HLS_IMAGE_FILTER=y
+# HLS_DECIMAL_MULT is not set
+# HLS_UDP is not set
+# HLS_RX100G is not set
+ACTION_HALF_WIDTH=y
+HALF_WIDTH="TRUE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+DISABLE_HBM=y
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+DISABLE_ETHERNET=y
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hls_memcopy_1024.defconfig
+++ b/defconfig/OC-AD9H335.hls_memcopy_1024.defconfig
@@ -1,0 +1,79 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+AD9H3=y
+# AD9H7 is not set
+FPGACARD="AD9H3"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="64"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu33p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HLS_ACTION is not set
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HDL_MULTI_PROCESS is not set
+# HDL_UNIT_SIM is not set
+# HLS_HELLOWORLD is not set
+HLS_MEMCOPY_1024=y
+HALF_WIDTH="FALSE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+# DISABLE_SDRAM_AND_BRAM is not set
+FORCE_SDRAM_OR_BRAM=y
+SDRAM_USED="FALSE"
+FORCE_HBM=y
+ENABLE_HBM=y
+HBM_USED="TRUE"
+# ENABLE_BRAM is not set
+BRAM_USED="FALSE"
+DDR3_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=3
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+# ENABLE_ODMA is not set
+ODMA_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-AD9H335.hls_udp_512.defconfig
+++ b/defconfig/OC-AD9H335.hls_udp_512.defconfig
@@ -1,0 +1,89 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+# AD9H3 is not set
+AD9H335=y
+# AD9H7 is not set
+# BW250SOC is not set
+FPGACARD="AD9H335"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="128"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xcvu35p-fsvh2104-2-e"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+# HLS_HELLOWORLD_PYTHON is not set
+# HLS_HBM_MEMCOPY_1024 is not set
+# HLS_IMAGE_FILTER is not set
+# HLS_DECIMAL_MULT is not set
+HLS_UDP=y
+# HLS_RX100G is not set
+ACTION_HALF_WIDTH=y
+HALF_WIDTH="TRUE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+DISABLE_HBM=y
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+ENABLE_ETHERNET=y
+# DISABLE_ETHERNET is not set
+# ENABLE_ETH_LOOP_BACK is not set
+ETH_LOOP_BACK="FALSE"
+ETHERNET_USED="TRUE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/hardware/setup/create_eth_100G_ip.tcl
+++ b/hardware/setup/create_eth_100G_ip.tcl
@@ -23,7 +23,7 @@ set vivadoVer    [version -short]
 set root_dir        $::env(SNAP_HARDWARE_ROOT)
 set fpga_part       $::env(FPGACHIP)
 set ip_dir          $root_dir/ip
-#set action_root     [expr int($::env(ACTION_ROOT))]
+#set action_root    $::env(ACTION_ROOT)
 set rx_fifo_depth   $::env(ETHERNET_RX_FIFO_DEPTH)
 
 if { [info exists ::env(ENABLE_EMAC_V3_1)] == 1 } {

--- a/hardware/setup/create_eth_100G_ip.tcl
+++ b/hardware/setup/create_eth_100G_ip.tcl
@@ -23,7 +23,7 @@ set vivadoVer    [version -short]
 set root_dir        $::env(SNAP_HARDWARE_ROOT)
 set fpga_part       $::env(FPGACHIP)
 set ip_dir          $root_dir/ip
-#set action_root     $::env(ACTION_ROOT)
+#set action_root     [expr int($::env(ACTION_ROOT))]
 
 if { [info exists ::env(ENABLE_EMAC_V3_1)] == 1 } {
   set emac_v3_1 [string toupper $::env(ENABLE_EMAC_V3_1)]
@@ -35,6 +35,10 @@ if { [info exists ::env(ENABLE_EMAC_V3_1)] == 1 } {
 set action_clock_freq "200MHz"
 #overide default value if variable exist
 #set action_clock_freq $::env(FPGA_ACTION_CLK)
+
+set rx_fifo_size $::env(ETHERNET_RX_FIFO_SIZE)
+
+puts $rx_fifo_size
 
 set project_name "eth_100G"
 set project_dir [file dirname [file dirname [file normalize [info script]]]]
@@ -113,8 +117,7 @@ update_ip_catalog -rebuild -scan_changes
   # Create instance: axis_data_fifo_1, and set properties
   set axis_data_fifo_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_data_fifo:2.0 axis_data_fifo_1 ]
   set_property -dict [ list \
-   CONFIG.FIFO_DEPTH {32768} \
-   CONFIG.FIFO_MEMORY_TYPE {ultra} \
+   CONFIG.FIFO_DEPTH $rx_fifo_size \
  ] $axis_data_fifo_1
 
   # Create instance: cmac_usplus_0, and set properties

--- a/hardware/setup/create_eth_100G_ip.tcl
+++ b/hardware/setup/create_eth_100G_ip.tcl
@@ -24,6 +24,7 @@ set root_dir        $::env(SNAP_HARDWARE_ROOT)
 set fpga_part       $::env(FPGACHIP)
 set ip_dir          $root_dir/ip
 #set action_root     [expr int($::env(ACTION_ROOT))]
+set rx_fifo_depth   $::env(ETHERNET_RX_FIFO_DEPTH)
 
 if { [info exists ::env(ENABLE_EMAC_V3_1)] == 1 } {
   set emac_v3_1 [string toupper $::env(ENABLE_EMAC_V3_1)]
@@ -35,10 +36,6 @@ if { [info exists ::env(ENABLE_EMAC_V3_1)] == 1 } {
 set action_clock_freq "200MHz"
 #overide default value if variable exist
 #set action_clock_freq $::env(FPGA_ACTION_CLK)
-
-set rx_fifo_size $::env(ETHERNET_RX_FIFO_SIZE)
-
-puts $rx_fifo_size
 
 set project_name "eth_100G"
 set project_dir [file dirname [file dirname [file normalize [info script]]]]
@@ -117,8 +114,14 @@ update_ip_catalog -rebuild -scan_changes
   # Create instance: axis_data_fifo_1, and set properties
   set axis_data_fifo_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_data_fifo:2.0 axis_data_fifo_1 ]
   set_property -dict [ list \
-   CONFIG.FIFO_DEPTH $rx_fifo_size \
+   CONFIG.FIFO_DEPTH $rx_fifo_depth \
  ] $axis_data_fifo_1
+
+  if  { [info exists ::env(ETHERNET_RX_FIFO_URAM)] == 1 } {
+     set_property -dict [ list \
+        CONFIG.FIFO_MEMORY_TYPE {ultra} \
+     ] $axis_data_fifo_1
+  }
 
   # Create instance: cmac_usplus_0, and set properties
   # This variable ENABLE_EMAC_V3_1 is set in scripts/snap_cfg and depends on vivado release

--- a/hardware/setup/patch_version.sh
+++ b/hardware/setup/patch_version.sh
@@ -55,7 +55,7 @@ elif [ "$FPGACARD" == "AD9H3" ]; then
   CARD_TYPE="32"
   SDRAM_SIZE="0"
 elif [ "$FPGACARD" == "AD9H335" ]; then
-  CARD_TYPE="32"
+  CARD_TYPE="35"
   SDRAM_SIZE="0"
 elif [ "$FPGACARD" == "AD9H7" ]; then
   CARD_TYPE="33"

--- a/hardware/setup/patch_version.sh
+++ b/hardware/setup/patch_version.sh
@@ -54,6 +54,9 @@ if [ "$FPGACARD" == "AD9V3" ]; then
 elif [ "$FPGACARD" == "AD9H3" ]; then
   CARD_TYPE="32"
   SDRAM_SIZE="0"
+elif [ "$FPGACARD" == "AD9H335" ]; then
+  CARD_TYPE="32"
+  SDRAM_SIZE="0"
 elif [ "$FPGACARD" == "AD9H7" ]; then
   CARD_TYPE="33"
   SDRAM_SIZE="0"

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -21,14 +21,14 @@ choice
 		  AlphaData 9V3 has ethernet and 16GB DDR4 SDRAM. Uses Xilinx FPGA VU3P.
 
 	config AD9H3
-		bool "OpenCAPI3.0: AlphaData 9H3 (VU33P with HBM)"
+		bool "OpenCAPI3.0: AlphaData 9H3 (incl. VU33P with HBM)"
 		select OPENCAPI30
 		select DISABLE_NVME
 		help
 		  AlphaData 9H3 has ethernet and 2x 4GB HBM Gen2. Uses Xilinx FPGA VU33P.
 
 	config AD9H335
-		bool "OpenCAPI3.0: AlphaData 9H3 (VU35P with HBM) (under development)"
+		bool "OpenCAPI3.0: AlphaData 9H3-35 (incl. VU35P with HBM) (under development)"
 		select OPENCAPI30
 		select DISABLE_NVME
 		help

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -308,7 +308,6 @@ choice
 		select ENABLE_SIMU_WO_ETH
 		select FORCE_SDRAM_OR_BRAM
 		select FORCE_HBM
-		select ACTION_HALF_WIDTH
 
 #	config HLS_SPONGE
 #		bool "HLS Sponge"

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -497,6 +497,12 @@ config ETHERNET_USED
         default "TRUE"  if  ENABLE_ETHERNET
         default "FALSE" if !ENABLE_ETHERNET
 
+config ETHERNET_RX_FIFO_SIZE
+        int
+        prompt "Size of receiving FIFO for Ethernet 100G MAC in 512-bit packates (must be power of 2)"
+        depends on ENABLE_ETHERNET
+        default 8192
+
 config USER_CLOCK
 	string
 	default "TRUE"  if ACTION_USER_CLOCK

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -497,11 +497,17 @@ config ETHERNET_USED
         default "TRUE"  if  ENABLE_ETHERNET
         default "FALSE" if !ENABLE_ETHERNET
 
-config ETHERNET_RX_FIFO_SIZE
+config ETHERNET_RX_FIFO_DEPTH
         int
-        prompt "Size of receiving FIFO for Ethernet 100G MAC in 512-bit packates (must be power of 2)"
+        prompt "Depth of receiving FIFO for Ethernet 100G MAC in 512-bit packates (must be power of 2)"
         depends on ENABLE_ETHERNET
         default 8192
+
+config ETHERNET_RX_FIFO_URAM
+	bool
+        prompt "Force implementation of receiving FIFO for Ethernet 100G MAC in UltraRAM"
+        depends on ENABLE_ETHERNET
+        default n
 
 config USER_CLOCK
 	string


### PR DESCRIPTION
1. Configure 100G ethernet RX FIFO using `make snap_config` scripts
2. Adjust one script + BSP for 9H3 with VU35P (temporarily links to fork of OC-BIP)
3. Use full registers for DSP cores in HLS (optional in Vivado HLS, default in Vitis HLS)
4. Small modifications to PSI actions description

