### PR TITLE
Fix ethernet clock in VU35P simulation

### DIFF
--- a/hardware/hdl/core/snap_global_vars.v_source
+++ b/hardware/hdl/core/snap_global_vars.v_source
@@ -31,6 +31,10 @@
 `define AD9H3
 #endif
 
+#if defined(CONFIG_AD9H335)
+`define AD9H3
+#endif
+
 #if defined(CONFIG_AD9H7)
 `define AD9H7
 #endif


### PR DESCRIPTION
Without declaring AD9H3 flag in SNAP global variables, simulation doesn't generate ethernet clock for AD9H3/VU35P (see also hardware/oc-bip/sim/src/top.sv:790). 

Signed-off-by: Filip Leonarski <filip.leonarski@psi.ch>